### PR TITLE
fix GetImageForCustomAttributeIndex

### DIFF
--- a/libil2cpp/vm/GlobalMetadata.cpp
+++ b/libil2cpp/vm/GlobalMetadata.cpp
@@ -1063,6 +1063,12 @@ static CustomAttributesCache* GenerateCustomAttributesCacheInternal(const Il2Cpp
 
 static const Il2CppImageGlobalMetadata* GetImageForCustomAttributeIndex(CustomAttributeIndex index)
 {
+    // ==={{ hybridclr
+    if (hybridclr::metadata::IsInterpreterIndex(index)) {
+        return reinterpret_cast<const Il2CppImageGlobalMetadata*>(hybridclr::metadata::MetadataModule::GetImageByEncodedIndex(index)->GetIl2CppImage()->metadataHandle);
+    }
+    // ===}} hybridclr
+
     for (int32_t imageIndex = 0; imageIndex < s_MetadataImagesCount; imageIndex++)
     {
         const Il2CppImageGlobalMetadata* imageMetadta = s_MetadataImagesTable + imageIndex;


### PR DESCRIPTION
fix: 当地址来自HybridCLR时，调用GetImageForCustomAttributeIndex提示"Failed to find owning image for custom attribute index"